### PR TITLE
[#14] 로그인 응답으로 토큰 저장하고, 로그인 여부에 따라 로그인페이지 라우팅 기능 구현

### DIFF
--- a/lib/app/screens/main_screen.dart
+++ b/lib/app/screens/main_screen.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+import 'package:wedding_app/app/screens/create_card_screen.dart';
+import 'package:wedding_app/app/screens/login_screen.dart';
+import 'package:wedding_app/calender_set/calender_package.dart';
+import 'package:wedding_app/tile_set/to_do_list_package.dart';
+
+class MainScreen extends StatelessWidget {
+  const MainScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.white,
+      appBar: AppBar(
+        backgroundColor: Colors.white,
+        elevation: 0,
+        centerTitle: true,
+        title: const Center(
+          child: Text(
+            "Our Wedding Diary",
+            style: TextStyle(
+              color: Colors.black,
+              fontWeight: FontWeight.bold,
+              fontSize: 32,
+            ),
+          ),
+        ),
+        actions: [
+          IconButton(
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (context) => LoginScreen()),
+              );
+            },
+            icon: const Icon(Icons.login),
+          ),
+          const Icon(
+            Icons.person,
+            color: Colors.black,
+            size: 32,
+          ),
+          const Icon(
+            Icons.settings,
+            color: Colors.black,
+            size: 32,
+          ),
+          IconButton(
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (context) => CreateCardScreen()),
+              );
+            },
+            icon: const Icon(Icons.add),
+          ),
+        ],
+      ),
+      body: Column(
+        children: [
+          Padding(
+            padding: EdgeInsets.symmetric(
+              horizontal: 64,
+            ),
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(8),
+              child: LinearProgressIndicator(
+                value: 0.3,
+                minHeight: 24,
+              ),
+            ),
+          ),
+          Flexible(
+            fit: FlexFit.tight,
+            child: Row(
+              children: [
+                Flexible(
+                  flex: 5,
+                  fit: FlexFit.tight,
+                  child: ToDoListPackage(),
+                ),
+                Flexible(
+                  flex: 2,
+                  fit: FlexFit.tight,
+                  child: CalenderPackage(),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/app/services/auth_service.dart
+++ b/lib/app/services/auth_service.dart
@@ -2,12 +2,27 @@ import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 import 'dart:convert';
 
+import 'package:shared_preferences/shared_preferences.dart';
+
 class AuthService extends ChangeNotifier {
+  bool _isLoggedIn = false;
+
+  bool get isLoggedIn => _isLoggedIn;
+
+  Future<bool> checkLoginStatus() async {
+    final prefs = await SharedPreferences.getInstance();
+    final token = prefs.getString('token');
+
+    _isLoggedIn = token != null;
+    notifyListeners();
+
+    return _isLoggedIn;
+  }
 
   Future<void> login(String email, String password) async {
     String url = "localhost:8080";
     final response = await http.post(
-      Uri.http(url, '/api/v1/users/login'),
+      Uri.http(url, '/api/v1/auth/login'),
       body: json.encode({
         'email': email,
         'password': password,
@@ -20,6 +35,16 @@ class AuthService extends ChangeNotifier {
     );
 
     if (response.statusCode == 200) {
+      final responseData = json.decode(response.body);
+      final token = responseData['token'];
+
+      // 토큰을 로컬 스토리지에 저장
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString('token', token);
+
+      _isLoggedIn = true;
+      notifyListeners();
+
       if (kDebugMode) {
         print('Login successful');
       }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,12 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:wedding_app/app/services/auth_service.dart';
-import 'package:wedding_app/calender_set/calender_package.dart';
 import 'package:wedding_app/service_set/tile_service.dart';
-import 'package:wedding_app/tile_set/to_do_list_package.dart';
 
-import 'app/screens/create_card_screen.dart';
 import 'app/screens/login_screen.dart';
+import 'app/screens/main_screen.dart';
 
 void main() {
   runApp(
@@ -31,86 +29,14 @@ class WeddingApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       debugShowCheckedModeBanner: false,
-      home: Builder( // Add this
-        builder: (context) => Scaffold(
-          backgroundColor: Colors.white,
-          appBar: AppBar(
-            backgroundColor: Colors.white,
-            elevation: 0,
-            centerTitle: true,
-            title: Center(
-              child: Text(
-                "Our Wedding Diary",
-                style: TextStyle(
-                  color: Colors.black,
-                  fontWeight: FontWeight.bold,
-                  fontSize: 32,
-                ),
-              ),
-            ),
-            actions: [
-              IconButton(
-                onPressed: () {
-                  Navigator.push(
-                    context,
-                    MaterialPageRoute(builder: (context) => LoginScreen()),
-                  );
-                },
-                icon: Icon(Icons.login),
-              ),
-              Icon(
-                Icons.person,
-                color: Colors.black,
-                size: 32,
-              ),
-              Icon(
-                Icons.settings,
-                color: Colors.black,
-                size: 32,
-              ),
-              IconButton(
-                  onPressed: () {
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute(builder: (context) => CreateCardScreen()),
-                    );
-                  }, icon: Icon(Icons.add)),
-            ],
-          ),
-          body: Column(
-            children: [
-              Padding(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 64,
-                ),
-                child: ClipRRect(
-                  borderRadius: BorderRadius.circular(8),
-                  child: LinearProgressIndicator(
-                    value: 0.3,
-                    minHeight: 24,
-                  ),
-                ),
-              ),
-              Flexible(
-                fit: FlexFit.tight,
-                child: Row(
-                  children: [
-                    Flexible(
-                      flex: 5,
-                      fit: FlexFit.tight,
-                      child: ToDoListPackage(),
-                    ),
-                    Flexible(
-                      flex: 2,
-                      fit: FlexFit.tight,
-                      child: CalenderPackage(),
-                    ),
-                  ],
-                ),
-              ),
-            ],
-          ),
-        ),
+      home: Consumer<AuthService>( // AuthService를 사용하여 로그인 상태 확인
+        builder: (context, authService, child) {
+          if (authService.isLoggedIn) { // 로그인되어 있으면 메인 화면으로 이동
+            return const MainScreen();
+          } else { // 로그인되어 있지 않으면 로그인 화면으로 이동
+            return LoginScreen();
+          }
+        },
       ),
     );
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -57,6 +57,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      sha256: "493f37e7df1804778ff3a53bd691d8692ddf69702cf4c1c1096a2e41b4779e21"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
+  file:
+    dependency: transitive
+    description:
+      name: file
+      sha256: "5fc22d7c25582e38ad9a8515372cd9a93834027aacf1801cf01164dac0ffa08c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -72,6 +88,11 @@ packages:
     version: "2.0.3"
   flutter_test:
     dependency: "direct dev"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
     description: flutter
     source: sdk
     version: "0.0.0"
@@ -171,6 +192,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.0"
+  path_provider_linux:
+    dependency: transitive
+    description:
+      name: path_provider_linux
+      sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
+  path_provider_platform_interface:
+    dependency: transitive
+    description:
+      name: path_provider_platform_interface
+      sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
+  path_provider_windows:
+    dependency: transitive
+    description:
+      name: path_provider_windows
+      sha256: "8bc9f22eee8690981c22aa7fc602f5c85b497a6fb2ceb35ee5a5e5ed85ad8170"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      sha256: "12220bb4b65720483f8fa9450b4332347737cf8213dd2840d8b2c823e47243ec"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.4"
+  plugin_platform_interface:
+    dependency: transitive
+    description:
+      name: plugin_platform_interface
+      sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.8"
   provider:
     dependency: "direct main"
     description:
@@ -179,6 +240,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.2"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      sha256: "81429e4481e1ccfb51ede496e916348668fd0921627779233bd24cc3ff6abd02"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.2"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: "8568a389334b6e83415b6aae55378e158fbc2314e074983362d20c562780fb06"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: "7708d83064f38060c7b39db12aefe449cb8cdc031d6062280087bc4cdb988f5c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.5"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: "9f2cbcf46d4270ea8be39fa156d86379077c8a5228d9dfdb1164ae0bb93f1faa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      sha256: "22e2ecac9419b4246d7c22bfbbda589e3acf5c0351137d87dd2939d984d37c3b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: "9aee1089b36bd2aafe06582b7d7817fd317ef05fc30e6ba14bff247d0933042a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: "841ad54f3c8381c480d0c9b508b89a34036f512482c407e6df7a9c4aa2ef8f59"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
   simple_gesture_detector:
     dependency: transitive
     description:
@@ -280,6 +397,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.5.1"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      sha256: "0a989dc7ca2bb51eac91e8fd00851297cfffd641aa7538b165c62637ca0eaa4a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.4.0"
+  xdg_directories:
+    dependency: transitive
+    description:
+      name: xdg_directories
+      sha256: faea9dee56b520b55a566385b84f2e8de55e7496104adada9962e0bd11bcff1d
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
 sdks:
   dart: ">=3.3.0 <4.0.0"
-  flutter: ">=1.17.0"
+  flutter: ">=3.19.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,7 @@ dependencies:
   table_calendar: ^3.0.9
   intl: ^0.18.1
   provider: ^6.0.5
+  shared_preferences: ^2.0.15
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
ticket: #14

## 기능 요약
- 로그인 응답으로 토큰 받기
- 토큰을 로컬 스토리지에 저장
- 로그인 API에 로그인 여부 플래그로 메인페이지와 로그인페이지 라우팅하는 기능 추가
- main.dart에 메인페이지 분리

## 화면
![image](https://github.com/Dan0804/wedding_app/assets/44468282/c432d4bd-6da2-40b2-9f03-6e6c8812e00c)

## Etc
- 로그인 후 메인페이지로 갔을 때, 카드 호출 API에도 헤더에 토큰 담아서 전달하는 기능 필요
- extands to: [#66](https://github.com/zeze1004/wedding-planner-backend/issues/66)