### PR TITLE
Http -> Https로 수정

### DIFF
--- a/lib/config.dart
+++ b/lib/config.dart
@@ -1,3 +1,3 @@
 class Config {
-  static const String apiUrl = "http://dev.wedding-jira.com/api/v1";
+  static const String apiUrl = "https://dev.wedding-jira.com/api/v1";
 }


### PR DESCRIPTION
프론트 도메인은 Https를 쓰고 백엔드는 Http를 써서 클라이언트에서 Http 요청을 블락함
```
Mixed Content: The page at 'https://wedding-jira.vercel.app/' was loaded over HTTPS, but requested an insecure XMLHttpRequest endpoint 'http://dev.wedding-jira.com/api/v1/auth/login'. This request has been blocked; the content must be served over HTTPS.
```

크롬 정책상 https는 https 에서 온 요청만 처리할 수 있으므로 백엔드 API를 https로 변경함